### PR TITLE
use consistent #include paths for dcmjpeg

### DIFF
--- a/io/multiresolutionimageinterface/VSIImage.cpp
+++ b/io/multiresolutionimageinterface/VSIImage.cpp
@@ -10,7 +10,7 @@
 // Include DCMTK LIBJPEG for lossy and lossless JPEG compression
 extern "C" {
 #define boolean ijg_boolean
-#include "dcmtk/dcmjpeg/libijg8/jpeglib8.h"
+#include "dcmjpeg/libijg8/jpeglib8.h"
 #include "jpeg_mem_src.h"
 #undef boolean
 #undef const


### PR DESCRIPTION
After this change, the following two files use the same relative path:
io/multiresolutionimageinterface/VSIImage.cpp
io/multiresolutionimageinterface/VSIImageReader.cpp
Also, it is now consistent with the FindDCMTKJPEG.cmake.

This is related to issue #2.