### PR TITLE
make compilation warning-free on Mac/CLang

### DIFF
--- a/annotation/Annotation.cpp
+++ b/annotation/Annotation.cpp
@@ -2,6 +2,7 @@
 #include "AnnotationGroup.h"
 #include "psimpl.h"
 #include <limits>
+#include <cmath>
 
 const char* Annotation::_typeStrings[5] = { "None", "Dot", "Polygon", "Spline", "PointSet"};
 
@@ -32,7 +33,7 @@ float Annotation::getArea() const {
       area += (_coordinates[j].getX() + _coordinates[i].getX())*(_coordinates[j].getY() - _coordinates[i].getY());
       j = i;
     }
-    return abs(area*.5);
+    return std::abs(area*.5);
   }
   else{
     return 0.0;

--- a/annotation/ImageScopeRepository.cpp
+++ b/annotation/ImageScopeRepository.cpp
@@ -159,4 +159,5 @@ bool ImageScopeRepository::loadFromRepo()
     _list->addGroup(grp);
     group_nr += 1;
 	}
+  return true;
 }

--- a/annotation/NDPARepository.cpp
+++ b/annotation/NDPARepository.cpp
@@ -93,4 +93,5 @@ bool NDPARepository::loadFromRepo()
       }
     }
 	}
+  return true;
 }

--- a/core/Box.cpp
+++ b/core/Box.cpp
@@ -77,8 +77,11 @@ Box Box::intersection(const Box& b) const {
   std::vector<unsigned long long> start(_start.size(),0), size(_start.size(),0);
   for (int i = 0; i < _start.size(); ++i) {
     start[i] = std::max(_start[i], b.getStart()[i]);
-    size[i] = std::min(_start[i] + _size[i], b.getStart()[i] + b.getSize()[i]) - start[i];
-    if (size[i] < 0) size[i] = 0;
+    unsigned long long end = std::min(_start[i] + _size[i], b.getStart()[i] + b.getSize()[i]);
+    if(end > start[i])
+      size[i] = end - start[i];
+    else
+      size[i] = 0;
   }
 
   return Box(start, size);

--- a/core/filetools.cpp
+++ b/core/filetools.cpp
@@ -436,7 +436,7 @@ namespace core
     string fixedPath = _fixedPath;
 
 //if a relative path cannot be written
-    if (! (rootName(pathToAlter)).compare(rootName(fixedPath)) == 0 )
+    if ( (rootName(pathToAlter)).compare(rootName(fixedPath)) != 0 )
       return pathToAlter;
 //if the two paths are the same
     if ( pathToAlter.compare(fixedPath) == 0)

--- a/io/multiresolutionimageinterface/LIFImage.cpp
+++ b/io/multiresolutionimageinterface/LIFImage.cpp
@@ -1,6 +1,7 @@
 #include "LIFImage.h"
 #include <fstream>
 #include <iostream>
+#include <cmath>
 #include "core/filetools.h"
 #include "core/stringconversion.h"
 #include "core/PathologyEnums.h"
@@ -553,7 +554,7 @@ void LIFImage::translateImageNodes(pugi::xpath_node&  imageNode, int imageNr)
   _physicalSizeYs.push_back(physicalSizeY);
 
   if (_zSteps[imageNr] == 0.0 && physicalSizeZ != 0.0) {
-    _zSteps[imageNr] = abs(physicalSizeZ);
+    _zSteps[imageNr] = std::abs(physicalSizeZ);
   }
 
   if (extras > 1) {

--- a/io/multiresolutionimageinterface/LIFImage.cpp
+++ b/io/multiresolutionimageinterface/LIFImage.cpp
@@ -122,7 +122,7 @@ bool LIFImage::initialize(const std::string& imagePath) {
       }
     }
     if (index < nc*2) {
-      editedXml[index] = NULL;
+      editedXml[index] = '\0';
     }
     std::string xml(editedXml);
 

--- a/io/multiresolutionimageinterface/MultiResolutionImage.cpp
+++ b/io/multiresolutionimageinterface/MultiResolutionImage.cpp
@@ -1,5 +1,6 @@
 #include "MultiResolutionImage.h"
 #include "boost/thread.hpp"
+#include <cmath>
 
 using namespace pathology;
 
@@ -168,7 +169,7 @@ const int MultiResolutionImage::getBestLevelForDownSample(const double& downsamp
       double previousDownSample = (double)_levelDimensions[0][0] / (double)_levelDimensions[i-1][0];
       if (downsample<currentDownSample) {
         
-        if (abs(currentDownSample - downsample) > abs(previousDownSample - downsample)) {
+        if (std::abs(currentDownSample - downsample) > std::abs(previousDownSample - downsample)) {
           return i - 1;
         }
         else {


### PR DESCRIPTION
Using LLVM version 7.3.0 (clang-703.0.31) with default settings.
Some commits may even fix tiny bugs.